### PR TITLE
Corrected typo in form label: "Studnet" to "Student" in CheckStudentD…

### DIFF
--- a/src/components/modals/CheckStudentDetails.tsx
+++ b/src/components/modals/CheckStudentDetails.tsx
@@ -167,7 +167,7 @@ export default function CheckStudentDetails({ children }: props) {
                 name="student_no"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>{"Studnet Phone Number (optional)"}</FormLabel>
+                    <FormLabel>{"Student Phone Number (optional)"}</FormLabel>
                     <FormControl>
                       <Input type="number" {...field} />
                     </FormControl>


### PR DESCRIPTION
…etails modal

This commit fixes a spelling error in the "CheckStudentDetails" modal component. In the form label for the student phone